### PR TITLE
fix(security): remove dangerous eval() usage in compare function

### DIFF
--- a/src/base/compare.js
+++ b/src/base/compare.js
@@ -5,14 +5,27 @@ import { typesToArray } from "../base";
  * @since 2.0.0
  * @param {PersianDate|Date|String|Array|Object} date - the date
  * @param {'>'|'>='|'<'|'<='|'=='} operator - the operator for compare
- * @returns {‌Boolean} if date valid, return true of false
+ * @returns {Boolean} if date valid, return true or false
  */
 export const compare = function (date, operator) {
 	date = typesToArray(this.c, ...date);
-
-	if (this.isValid(...date))
-		return eval(
-			"this.timestamp()" + operator + "this.clone().parse(...date).timestamp()"
-		);
-	return false;
+	if (!this.isValid(...date)) return false;
+	const thisTimestamp = this.timestamp();
+	const otherTimestamp = this.clone().parse(...date).timestamp();
+	switch (operator) {
+		case '>':
+			return thisTimestamp > otherTimestamp;
+		case '>=':
+			return thisTimestamp >= otherTimestamp;
+		case '<':
+			return thisTimestamp < otherTimestamp;
+		case '<=':
+			return thisTimestamp <= otherTimestamp;
+		case '==':
+		case '===':
+			return thisTimestamp === otherTimestamp;
+		default:
+			// Handle invalid operator safely (return false or throw error)
+			return false;
+	}
 };


### PR DESCRIPTION
Refactored the `compare` function to use a safe `switch` statement instead of `eval()` for date comparisons. This eliminates a potential Code Injection/Remote Code Execution (RCE) vulnerability where a manipulated `operator` argument could execute arbitrary code.

I always support being lazy but also I always avoid using eval as much as possible

fixes #5 